### PR TITLE
Delete temporary files when deleting the AnalyzeResult object they belong to

### DIFF
--- a/analyzefiletask.cpp
+++ b/analyzefiletask.cpp
@@ -19,7 +19,6 @@ void AnalyzeFileTask::doanalyze()
 	result->fileName = m_path;
 
 	QStringList arguments;
-	result->m_tmpFile = new QTemporaryFile();
 	if (result->m_tmpFile->open()) {
 		arguments << m_path << result->m_tmpFile->fileName() << m_profile;
 		extractor = new QProcess(this);

--- a/analyzefiletask.h
+++ b/analyzefiletask.h
@@ -25,6 +25,11 @@ struct AnalyzeResult
 	QString errorMessage;
 	AnalyzeFileTask *m_task;
 	QTemporaryFile *m_tmpFile;
+
+	~AnalyzeResult()
+	{
+		delete m_tmpFile;
+	}
 };
 
 class AnalyzeFileTask : public QObject

--- a/analyzefiletask.h
+++ b/analyzefiletask.h
@@ -11,9 +11,10 @@ class AnalyzeFileTask;
 
 struct AnalyzeResult
 {
-	AnalyzeResult(AnalyzeFileTask *task) : error(false)
+	AnalyzeResult(AnalyzeFileTask *task)
+	: error(false), m_task(task)
 	{
-		m_task = task;
+		m_tmpFile = new QTemporaryFile();
 	}
 
 	QString fileName;


### PR DESCRIPTION
I usually don't do C++, but this looks like it should work.