### PR TITLE
Run an ideal number of stream extractor instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ To run
 Run the `acousticbrainz-gui` program. Select folders that contain music tagged
 with MusicBrainz identifiers. Click Analyze.
 
+*Note:* Since all available CPU threads will be used, consider lowering the priority of
+`acousticbrainz-gui` -- all new invocations of `streaming_extractor_music` will
+adopt the new priority. If the priority is changed while analysis is ongoing, it
+may take a few minutes for the new priority to be completely adopted while existing
+invocations of `streaming_extractor_music` finish.
+
 Dependencies
 ------------
 

--- a/constants.h
+++ b/constants.h
@@ -4,6 +4,5 @@
 static const char *API_KEY_URL = "http://acousticbrainz.org";
 static const char *SUBMIT_URL = "http://acousticbrainz.org/%1/low-level";
 //static const char *SUBMIT_URL = "http://127.0.0.1:8080/%1/low-level";
-static const int MAX_ACTIVE_FILES = 3;
 
 #endif

--- a/extractor.cpp
+++ b/extractor.cpp
@@ -133,7 +133,7 @@ void Extractor::onFileListLoaded(const QStringList &files)
 		return;
 	}
 	emit extractionStarted(files.size());
-	while (!m_files.isEmpty() && m_activeFiles < MAX_ACTIVE_FILES) {
+	while (!m_files.isEmpty() && m_activeFiles < QThread::idealThreadCount()) {
 		extractNextFile();
 	}
 }


### PR DESCRIPTION
Closes #15.

As suggested in that ticket, this change uses `QThread::idealThreadCount()` to determine the number of stream extractors that should be running.

To head off any concern about the reponsive of the machine while analysis is running, I've added a section to the README recommending to lower the priority of the GUI process.  This propagates the process priority to new invocations of the stream extractor on Windows and nice values should be propagated on Linux. However, I cannot confirm macOS.

I'm not a C++ developer, a `cmake` user, or used to building much on Windows, so any advice would be greatly appreciated.

I did look in to programmatically setting the priority on the `QProcess`es used for running the stream extractor, but that appeared to require writing cross-platform code to do so, and I'm already out of my depth as-is!

I've posted a Windows build here:
https://github.com/XanderXAJ/acousticbrainz-gui/releases/tag/ideal-threads