### PR TITLE
Easier Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,4 +112,7 @@ if(WIN32)
 	install(CODE [=[
 		execute_process(COMMAND "${WINDEPLOYQT_EXECUTABLE}" "bin/$<TARGET_FILE_NAME:acousticbrainz-gui>" WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}")
 	]=])
+
+	# For convenience, include the stream extractor executable if it is present in the source directory
+	install(PROGRAMS streaming_extractor_music.exe DESTINATION bin OPTIONAL)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,7 @@ set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include CACHE PATH "Installation
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
-find_package(Qt5Widgets)
-find_package(Qt5Network)
+find_package(Qt5 COMPONENTS Widgets Network REQUIRED)
 
 if(CMAKE_BUILD_TYPE STREQUAL Release OR CMAKE_BUILD_TYPE STREQUAL MinSizeRel OR CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
 	add_definitions(-DQT_NO_DEBUG_OUTPUT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(APPLE)
 endif()
 
 add_executable(acousticbrainz-gui ${GUI_TYPE} ${acousticbrainz-gui_SOURCES})
-qt5_use_modules(acousticbrainz-gui Widgets Network)
+target_link_libraries(acousticbrainz-gui Qt5::Widgets Qt5::Network)
 
 
 set_target_properties(acousticbrainz-gui PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.14)
+
+# Allow the use of generator expressions in install(CODE) (requires cmake 3.14)
+# https://cmake.org/cmake/help/latest/policy/CMP0087.html
+cmake_policy(SET CMP0087 NEW)
 
 project(acousticbrainz-gui)
 set(acousticbrainz-gui_VERSION 0.2dev)
@@ -90,4 +94,22 @@ if(APPLE)
     install(TARGETS acousticbrainz-gui BUNDLE DESTINATION .)
 elseif(UNIX)
     install(TARGETS acousticbrainz-gui RUNTIME DESTINATION ${BIN_INSTALL_DIR})
+endif()
+
+if(WIN32)
+	# Install Windows system libraries alongside application
+	set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)
+	include(InstallRequiredSystemLibraries)
+
+	# Find the windeployqt executable, used for copying necessary QT libs alongside the application
+	get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+	get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
+	find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
+
+	# Install QT dependencies alongside application
+	install(TARGETS acousticbrainz-gui BUNDLE)
+	install(CODE "set(WINDEPLOYQT_EXECUTABLE \"${WINDEPLOYQT_EXECUTABLE}\")")
+	install(CODE [=[
+		execute_process(COMMAND "${WINDEPLOYQT_EXECUTABLE}" "bin/$<TARGET_FILE_NAME:acousticbrainz-gui>" WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}")
+	]=])
 endif()


### PR DESCRIPTION
While trying to make #22, I struggled to build the Windows executable with its dependencies in an appropriate place for it to run.  I was going to have to manually copy files around, including the extractor, and I felt like I was going to get fed up of that very quickly! So I investigated trying to automate it...

This pull request represents my efforts.  It does three things:

1. It includes Windows system libraries in the application install directory;
2. It includes QT libraries in the application install directory (by running `windeployqt`);
3. It optionally copies `streaming_extractor_music.exe` to the application install directory if it is present in the source directory.

Use of generator expressions in the `install(CODE)` raises the minimum version of `cmake` to 3.14 (basically the latest). If this is considered too new, then the `$<TARGET_FILE_NAME:acousticbrainz-gui>` could probably be replaced with a hardcoded `acousticbrainz-gui.exe`. However, I wanted to avoid hardcoded things where I could.

I'm not a C++ developer, a `cmake` user, or used to building much on Windows, so any advice would be greatly appreciated.

I was using this (probably nuclear) command to perform an out-of-source build from beginning to end (via Git Bash on Windows):
```
( rm -fr build && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/c/Qt/5.12.3/msvc2017_64/ -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_INSTALL_PREFIX=_install .. && cmake --build . --config Release --target install )
```